### PR TITLE
feat(airflow): add Spark DAG sample

### DIFF
--- a/08_airflow/Dockerfile
+++ b/08_airflow/Dockerfile
@@ -1,0 +1,26 @@
+FROM apache/airflow:2.9.2
+
+USER root
+
+RUN apt-get update && \
+    apt install -y default-jdk wget && \
+    apt-get autoremove -yqq --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz && \
+    mkdir -p /opt/spark && \
+    tar -xvf spark-3.4.2-bin-hadoop3.tgz -C /opt/spark && \
+    rm spark-3.4.2-bin-hadoop3.tgz
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV SPARK_HOME=/opt/spark/spark-3.4.2-bin-hadoop3
+ENV PATH=$PATH:$JAVA_HOME/bin:$SPARK_HOME/bin
+ENV PYTHONPATH=$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip
+
+COPY requirements.txt /requirements.txt
+RUN chmod 777 /requirements.txt
+
+USER airflow
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r /requirements.txt

--- a/08_airflow/dags/main.py
+++ b/08_airflow/dags/main.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from pyspark.sql import DataFrame, SparkSession
+
+
+def run_spark_job() -> None:
+    spark: SparkSession = SparkSession.builder \
+        .appName("Airflow_PySpark_Example") \
+        .master("local") \
+        .getOrCreate()
+
+    data: list[tuple[str, int]] = [("Alice", 1), ("Bob", 2), ("Charlie", 3)]
+
+    df: DataFrame = spark.createDataFrame(data, ["name", "id"])
+
+    df.show()
+    spark.stop()
+
+
+with DAG(
+        dag_id="main",
+        start_date=datetime(2023, 10, 1),
+        schedule_interval="@daily",
+        catchup=False,
+) as dag:
+    run_pyspark_task: PythonOperator = PythonOperator(
+        task_id="run_pyspark_task",
+        python_callable=run_spark_job,
+    )
+
+run_pyspark_task

--- a/08_airflow/docker-compose.yml
+++ b/08_airflow/docker-compose.yml
@@ -1,0 +1,140 @@
+x-airflow-common:
+  &airflow-common
+  image: ${AIRFLOW_IMAGE_NAME:-airflow-with-java}
+  environment:
+    &airflow-common-env
+    AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
+    AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
+    AIRFLOW__CORE__FERNET_KEY: ''
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
+    AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
+    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+  volumes:
+    - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
+    - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
+    - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
+    - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+  user: "${AIRFLOW_UID:-50000}:0"
+  depends_on:
+    &airflow-common-depends-on
+    redis:
+      condition: service_healthy
+    postgres:
+      condition: service_healthy
+
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+    restart: always
+
+  redis:
+    image: redis:7.2-bookworm
+    expose:
+      - 6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 30s
+      retries: 50
+      start_period: 30s
+    restart: always
+
+  airflow-webserver:
+    <<: *airflow-common
+    command: webserver
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-scheduler:
+    <<: *airflow-common
+    command: scheduler
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-worker:
+    <<: *airflow-common
+    command: celery worker
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - 'celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}" || celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"'
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    environment:
+      <<: *airflow-common-env
+      DUMB_INIT_SETSID: "0"
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-init:
+    <<: *airflow-common
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        if [[ -z "${AIRFLOW_UID}" ]]; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: AIRFLOW_UID not set!\e[0m"
+          echo "If you are on Linux, you SHOULD follow the instructions below to set "
+          echo "AIRFLOW_UID environment variable, otherwise files will be owned by root."
+          echo
+        fi
+        mkdir -p /sources/logs /sources/dags /sources/plugins
+        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
+        exec /entrypoint airflow version
+    environment:
+      <<: *airflow-common-env
+      _AIRFLOW_DB_MIGRATE: 'true'
+      _AIRFLOW_WWW_USER_CREATE: 'true'
+      _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
+      _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
+      _PIP_ADDITIONAL_REQUIREMENTS: ''
+    user: "0:0"
+    volumes:
+      - ${AIRFLOW_PROJ_DIR:-.}:/sources
+
+networks:
+  default:
+
+volumes:
+  postgres-db-volume:

--- a/08_airflow/requirements.txt
+++ b/08_airflow/requirements.txt
@@ -1,0 +1,6 @@
+pyspark==3.4.2
+py4j==0.10.9.7
+clickhouse-connect==0.8.0
+airflow-providers-clickhouse==0.0.1
+clickhouse-driver==0.2.9
+airflow-clickhouse-plugin


### PR DESCRIPTION
## Summary
- Adds an Airflow + PySpark sample under `08_airflow`.
- Includes Dockerfile, docker-compose setup, pinned Python requirements, and a simple DAG.
- Runtime files such as `.idea`, `.venv`, `logs`, and `__pycache__` are intentionally excluded.

## Validation
- `python -m py_compile 08_airflow/dags/main.py` passed.
- `docker compose -f 08_airflow/docker-compose.yml config --quiet` was not run because Docker is not installed in the local environment.